### PR TITLE
Replace gdown with wget and hf download on the installation script

### DIFF
--- a/scripts/installation/install.sh
+++ b/scripts/installation/install.sh
@@ -2,7 +2,8 @@
 mkdir -p third_party/mega-sam/Depth-Anything/checkpoints
 wget -O third_party/mega-sam/Depth-Anything/checkpoints/depth_anything_vitl14.pth \
   https://huggingface.co/spaces/LiheYoung/Depth-Anything/resolve/main/checkpoints/depth_anything_vitl14.pth
-gdown --id 1MqDajR89k-xLV0HIrmJ0k-n8ZpG6_suM -O third_party/mega-sam/cvd_opt/raft-things.pth
+wget -O third_party/mega-sam/cvd_opt/raft-things.pth \
+  https://huggingface.co/datasets/licesma/raft_things/resolve/main/raft-things.pth
 
 # segmentation
 wget -O third_party/Grounded-SAM-2/checkpoints/sam2.1_hiera_large.pt \
@@ -15,7 +16,7 @@ cd /app/third_party/Grounded-SAM-2 && \
 
 # foundation pose
 mkdir -p third_party/FoundationPose/weights
-gdown --folder 1DFezOAD0oD1BblsXVxqDsl8fj0qzB82i -O third_party/FoundationPose/weights
+hf download licesma/foundationpose_weights --repo-type dataset --local-dir third_party/FoundationPose/weights
 
 # foundation pose compile
 cd /app/third_party/FoundationPose/mycpp && \


### PR DESCRIPTION
Gdown fails to download foundationpose weights with the message "To many people are viewing the file right now".

Copied the files to a huggingface repo and use hf download instead, to avoid relying on gdown, I did the same thing for raft_things.