### PR TITLE
Modify install script and add video utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ docker compose -p "$USER" -f docker/compose.yml run --rm openreal2sim
 
 **Inside the docker container**, run the following script to download pretrained checkpoints and compile c++/cuda extensions:
 ```
-bash scripts/installation/install.sh
+python scripts/installation/install.py
 ```
 
 **Tips if you are using VSCode**:

--- a/docker/requirements.docker.txt
+++ b/docker/requirements.docker.txt
@@ -12,7 +12,7 @@ tqdm==4.67.1
 opencv-python-headless==4.9.0.80
 PyYAML==6.0.2
 einops==0.8.1
-huggingface-hub==0.29.2
+huggingface-hub[cli]==0.29.2
 imageio==2.36.0
 timm==1.0.19
 safetensors==0.6.2

--- a/scripts/installation/install.py
+++ b/scripts/installation/install.py
@@ -1,0 +1,94 @@
+import os
+import subprocess
+import sys
+from urllib.request import urlretrieve
+from huggingface_hub import snapshot_download
+
+def run_command(command, cwd=None):
+    """Runs a command in a subprocess and checks for errors."""
+    print(f"Running command: {' '.join(command)} in {cwd or os.getcwd()}")
+    process = subprocess.run(command, cwd=cwd, check=True, text=True, capture_output=True)
+    # Print stdout/stderr only if there's an error, or for verbose logging if desired
+    if process.returncode != 0:
+        print(f"ERROR: Command failed with exit code {process.returncode}")
+        print("--- STDOUT ---")
+        print(process.stdout)
+        print("--- STDERR ---")
+        print(process.stderr)
+        sys.exit(1) # Exit script on failure
+
+def download_file(url, destination):
+    """Downloads a file, creating the destination directory if needed."""
+    dest_dir = os.path.dirname(destination)
+    print(f"Ensuring directory exists: {dest_dir}")
+    os.makedirs(dest_dir, exist_ok=True)
+    file_name = url.split('/')[-1]
+    print(f"Downloading {file_name} to {destination}...")
+    urlretrieve(url, destination)
+    print("Download complete.")
+
+def main():
+    """Main function to set up all dependencies."""
+    # Ensure we are in the correct base directory
+    base_dir = "/app"
+    os.chdir(base_dir)
+    print(f"Working directory set to: {os.getcwd()}")
+
+    # --- Mega-SAM Dependencies ---
+    print("\n--- [1/6] Setting up Mega-SAM dependencies ---")
+    download_file(
+        "https://huggingface.co/spaces/LiheYoung/Depth-Anything/resolve/main/checkpoints/depth_anything_vitl14.pth",
+        "third_party/mega-sam/Depth-Anything/checkpoints/depth_anything_vitl14.pth"
+    )
+    download_file(
+        "https://huggingface.co/datasets/licesma/raft_things/resolve/main/raft-things.pth",
+        "third_party/mega-sam/cvd_opt/raft-things.pth"
+    )
+
+    # --- Segmentation Dependencies (Grounded-SAM-2) ---
+    print("\n--- [2/6] Downloading Segmentation model ---")
+    download_file(
+        "https://dl.fbaipublicfiles.com/segment_anything_2/092824/sam2.1_hiera_large.pt",
+        "third_party/Grounded-SAM-2/checkpoints/sam2.1_hiera_large.pt"
+    )
+
+    print("\n--- [3/6] Building Segmentation CUDA extension ---")
+    build_cuda_path = os.path.join(base_dir, "third_party/Grounded-SAM-2")
+    run_command(
+        [sys.executable, "build_cuda.py", "build_ext", "--inplace", "-v"],
+        cwd=build_cuda_path
+    )
+
+    # --- FoundationPose Dependencies ---
+    print("\n--- [4/6] Downloading FoundationPose weights ---")
+    fp_weights_dir = os.path.join(base_dir, "third_party/FoundationPose/weights")
+    os.makedirs(fp_weights_dir, exist_ok=True)
+    snapshot_download(
+        repo_id="licesma/foundationpose_weights",
+        repo_type="dataset",
+        local_dir=fp_weights_dir
+    )
+
+    print("\n--- [5/6] Compiling FoundationPose C++ extension ---")
+    fp_cpp_build_path = os.path.join(base_dir, "third_party/FoundationPose/mycpp/build")
+    run_command(["rm", "-rf", fp_cpp_build_path])
+    os.makedirs(fp_cpp_build_path, exist_ok=True)
+    run_command(
+        ["cmake", "..", f"-DPYTHON_EXECUTABLE={sys.executable}"],
+        cwd=fp_cpp_build_path
+    )
+    run_command(["make", "-j11"], cwd=fp_cpp_build_path)
+
+    print("\n--- [6/6] Compiling FoundationPose bundlesdf CUDA extension ---")
+    fp_bundlesdf_path = os.path.join(base_dir, "third_party/FoundationPose/bundlesdf/mycuda")
+    run_command(["rm", "-rf", "build"], cwd=fp_bundlesdf_path) 
+    run_command(["rm", "-rf", "*.egg-info"], cwd=fp_bundlesdf_path) 
+    run_command(
+        [sys.executable, "-m", "pip", "install", ".", "--no-build-isolation"],
+        cwd=fp_bundlesdf_path
+    )
+
+    print("\n\n--- All dependencies set up successfully! ---")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/video_utils/extract_first_frame.py
+++ b/scripts/video_utils/extract_first_frame.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""
+Extracts and optionally resizes the first frame of a series of MP4 videos.
+
+For each video:
+  • Extracts the first frame (`-frames:v 1`).
+  • Optionally resizes it (if `resize` is True) to the specified resolution.
+
+Common resolutions:
+  - 1080p → 1920 x 1080
+  - 720p  → 1280 x 720
+  - 480p  → 854 x 480
+"""
+
+import os, subprocess
+
+# === Configuration ===
+data_path = "data"
+label = "basic_pick_place_"  
+first_index = 10
+last_index = 29
+
+resize = True         # Set to False to keep original resolution
+width, height = 1280, 720  
+
+# === Processing Loop ===
+for i in range(first_index, last_index + 1):
+    input_path = os.path.join(data_path, f"{label}{i}.mp4")
+    output_path = os.path.join(data_path, f"{label}{i}.jpg")
+
+    print(f"Extracting first frame from {input_path} → {output_path}")
+
+    cmd = [
+    "ffmpeg", "-y", "-hide_banner", "-loglevel", "error",
+    "-i", input_path,
+    "-frames:v", "1",
+    ]
+    if resize:
+        cmd += ["-vf", f"scale={width}:{height}"]
+    cmd += [output_path]
+
+    subprocess.run(cmd, check=True)
+    print(f"Saved {output_path}")

--- a/scripts/video_utils/reencode.py
+++ b/scripts/video_utils/reencode.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""
+Converts videos recorded with legacy codecs (like MPEG-4 Part 2 or HEVC)
+    into standard H.264 for better playback support.
+
+For each video in the specified index range:
+  1. Re-encodes it into H.264 video + AAC audio (web-safe, browser-compatible).
+  2. Forces 8-bit YUV 4:2:0 pixel format (yuv420p), ensuring compatibility with
+     Chromium-based players (e.g. VS Code, Chrome).
+  3. Applies `-movflags +faststart`, which moves the MP4 header to the beginning
+     of the file so it can start playing before the full file loads.
+"""
+import subprocess
+import os
+# === Configuration ===
+data_path = "data"
+label = "basic_pick_place_" 
+first_index = 10
+last_index = 29
+
+# === Processing Loop ===
+for i in range(first_index, last_index + 1):
+    input_path = os.path.join(data_path, f"{label}{i}.mp4")
+    tmp_output = os.path.join(data_path, f"{label}{i}_tmp.mp4")
+
+    print(f"Re-encoding {input_path}")
+
+    cmd = [
+        "ffmpeg", "-y", "-hide_banner", "-loglevel", "error",
+        "-i", input_path,
+        "-c:v", "libx264",
+        "-pix_fmt", "yuv420p",
+        "-preset", "fast",
+        "-crf", "20",
+        "-c:a", "aac",
+        "-b:a", "160k",
+        "-movflags", "+faststart",
+        tmp_output
+    ]
+    subprocess.run(cmd, check=True)
+    os.replace(tmp_output, input_path)


### PR DESCRIPTION
This PR modifies the install script, now it uses python  instead of bash, the script's output is now cleaner and it stops if any of the installation or download fails, so it is easier to debug.

Additionally I added a couple of video_utils script that are useful when uploading videos from sources that have non-visible encodings on vscode