### PR TITLE
Make docker user match with server's user

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -65,7 +65,7 @@ Every time you want to run a script inside the repo, follow these steps:
 
 **Run the container**
    ```bash
-   docker compose -p "$USER" -f docker/compose.yml run openreal2sim
+   HOST_UID=$(id -u) HOST_GID=$(id -g) docker compose -p "$USER" -f docker/compose.yml run openreal2sim
    ```
 
 **Execute a script inside the container**

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   # Real To Sim [Master Container]
   openreal2sim:
@@ -14,11 +12,17 @@ services:
           devices:
             - driver: nvidia
               count: all
-              capabilities: [gpu]
+              capabilities: [ gpu ]
+    environment:
+      - Home=/tmp
     working_dir: /app
     volumes:
+      - /etc/passwd:/etc/passwd:ro
+      - /etc/group:/etc/group:ro
+      - ${HOME}:${HOME}
       - ../:/app
     stdin_open: true
+    user: "${HOST_UID}:${HOST_GID}"
     tty: true
     command: bash
 
@@ -33,18 +37,18 @@ services:
           devices:
             - driver: nvidia
               count: all
-              capabilities: [gpu]
+              capabilities: [ gpu ]
     working_dir: /app
     volumes:
       - ../:/app
-      - /tmp/.X11-unix:/tmp/.X11-unix:rw        # forward X11 socket
-      - ${XAUTHORITY:-$HOME/.Xauthority}:/home/isaac/.Xauthority:ro  # X auth cookie
-      - /dev:/dev                                # add: expose input/gpu devices if needed
+      - /tmp/.X11-unix:/tmp/.X11-unix:rw # forward X11 socket
+      - ${XAUTHORITY:-$HOME/.Xauthority}:/home/isaac/.Xauthority:ro # X auth cookie
+      - /dev:/dev # add: expose input/gpu devices if needed
     environment:
-      - DISPLAY=${DISPLAY}            # add: pass host DISPLAY
-      - XAUTHORITY=/home/isaac/.Xauthority  # add: where the cookie is mounted in container
-      - QT_X11_NO_MITSHM=1            # add: avoid MIT-SHM issues for GUI apps
-      - NVIDIA_VISIBLE_DEVICES=all    # add: be explicit
+      - DISPLAY=${DISPLAY} # add: pass host DISPLAY
+      - XAUTHORITY=/home/isaac/.Xauthority # add: where the cookie is mounted in container
+      - QT_X11_NO_MITSHM=1 # add: avoid MIT-SHM issues for GUI apps
+      - NVIDIA_VISIBLE_DEVICES=all # add: be explicit
       - NVIDIA_DRIVER_CAPABILITIES=all # add: include graphics/display
       - OMNI_KIT_DISABLE_EXTS=isaacsim.ros2.bridge
       # (Optional Wayland; uncomment if you run Wayland)
@@ -52,9 +56,9 @@ services:
       # - XDG_RUNTIME_DIR=/run/user/${UID}
       # - XDG_SESSION_TYPE=wayland
     devices:
-      - /dev/dri:/dev/dri             # add: direct rendering device (helps GUI/GL)
+      - /dev/dri:/dev/dri # add: direct rendering device (helps GUI/GL)
     # ipc: host                          # add: larger /dev/shm helps Isaac
-    shm_size: "16g"                    # add: extra SHM for stability
+    shm_size: "16g" # add: extra SHM for stability
     stdin_open: true
     tty: true
     command: bash


### PR DESCRIPTION
Currently, the container runs as the root user by default.

This causes file permission issues, as files created by root in the container cannot be edited by the host user.

This PR solves this by passing the host's User ID (UID) and Group ID (GID) to the container. 3 new bind mounts are added as volumes:
/etc/passwd:ro and /etc/group:ro: Allows the container to map the numeric UID/GID to a username (e.g., 1044 -> esteban).
${HOME}:${HOME}: Provides a writable home directory for VS Code to install its .vscode-server files when attaching to the container.