### PR TITLE
Prevent Image Drag on Segmentation Annotator

### DIFF
--- a/openreal2sim/reconstruction/tools/segmentation_annotator.py
+++ b/openreal2sim/reconstruction/tools/segmentation_annotator.py
@@ -308,7 +308,7 @@ with gr.Blocks(title="Grounded-SAM-2 Annotator", css=css_prevent_image_drag) as 
         del_btn = gr.Button("Delete Object")
 
     slider = gr.Slider(0,1,1,label="Frame",interactive=False)
-    imgbox = gr.Image(type="numpy",label="Preview")
+    imgbox = gr.Image(type="numpy",label="Preview", elem_id="sam-image-box")
 
     prop_btn, logbox = gr.Button("PROPAGATE & SAVE"), gr.Textbox(label="Log")
 


### PR DESCRIPTION
When annotating an image, if accidentally one drags one of the clicks, the image is gone and all the masks are erased because the imgbox gets reseted. 

This css change prevents images inside the imbox id to be "draggable".