### PR TITLE
Create preprocess manager script

### DIFF
--- a/openreal2sim/preprocess/README.md
+++ b/openreal2sim/preprocess/README.md
@@ -85,7 +85,12 @@ local:
 
 If everything is ready, run the all-in-one script:
 ```
-bash scripts/running/preprocess.sh
+python openreal2sim/preprocess/preprocess_manager.py
+```
+
+The pipeline can be executed with a custom config file:
+```
+python openreal2sim/preprocess/preproces_manager.py --config <path_to_config_file>
 ```
 
 Or run per-step:

--- a/openreal2sim/preprocess/depth_calibration.py
+++ b/openreal2sim/preprocess/depth_calibration.py
@@ -11,13 +11,13 @@ Outputs:
     - outputs/{key_name}/scene/scene.pkl (refined frames, depths, and camera infos)
 Notes:
     - for a single image, calibrate the predicted depth to real-world scale with the provided ground truth depth (data/{key_name}_depth.png)
-    - for multiple frames, calibrate the predicted depth to real-world scale with the provided ground truth depth (data/{key_name}_depth.png) on the first frame, 
+    - for multiple frames, calibrate the predicted depth to real-world scale with the provided ground truth depth (data/{key_name}_depth.png) on the first frame,
         and apply the same scale and shift to all frames
     - optionally, refine the predicted depth (Unidepth+DepthAnything) with monocular depth prediction (MoGe-2) before calibration
     - optionally, replace the camera intrinsics in scene/scene.pkl with the one from config.yaml
 """
 
-
+import argparse
 from pathlib import Path
 from typing import Tuple, List
 import numpy as np
@@ -311,10 +311,18 @@ def process_key(key: str, key_cfgs: dict) -> None:
     return
 
 # --------------------- main: read YAML and run ---------------------
-if __name__ == "__main__":
-    cfg_path = base_dir / "config" / "config.yaml"
+def main(config_file: str = "config/config.yaml"):
+    """Main function: load config and process depth calibration."""
+    cfg_path = base_dir / config_file
     cfg = yaml.safe_load(cfg_path.open("r"))
     keys = cfg["keys"]
     for key in keys:
         key_cfgs = compose_configs(key, cfg)
         process_key(key, key_cfgs)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config", type=str, default="config/config.yaml", help="YAML with keys: [lab1, ...]")
+    args = parser.parse_args()
+
+    main(args.config)

--- a/openreal2sim/preprocess/depth_prediction.py
+++ b/openreal2sim/preprocess/depth_prediction.py
@@ -204,17 +204,14 @@ def mode_check(key_name: str) -> str:
     else:
         return "video"
 
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--key_name", type=str, default=None, help="If set, run only this key")
-    parser.add_argument("--config", type=str, default="config/config.yaml", help="YAML with keys: [lab1, ...]")
-    args = parser.parse_args()
+def main(config_file: str = "config/config.yaml", key_name: str = None):
+    """Main function: load config and run depth prediction."""
+    with open(config_file, "r") as f:
+        cfg = yaml.safe_load(f)
 
-    if args.key_name is not None:
-        keys = [args.key_name]
+    if key_name is not None:
+        keys = [key_name]
     else:
-        with open(args.config, "r") as f:
-            cfg = yaml.safe_load(f)
         keys = [k for k in cfg["keys"]]
 
     for key in keys:
@@ -226,3 +223,11 @@ if __name__ == "__main__":
         else:
             print(f"[Info] Running moge for image: {key}")
             run_moge(key, key_cfgs)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--key_name", type=str, default=None, help="If set, run only this key")
+    parser.add_argument("--config", type=str, default="config/config.yaml", help="YAML with keys: [lab1, ...]")
+    args = parser.parse_args()
+
+    main(args.config, args.key_name)

--- a/openreal2sim/preprocess/image_extraction.py
+++ b/openreal2sim/preprocess/image_extraction.py
@@ -15,6 +15,7 @@ Parameters:
 """
 
 import os
+import argparse
 import subprocess
 import yaml
 from pathlib import Path
@@ -164,4 +165,8 @@ def main(config_file: str = "config/config.yaml"):
         run_collect_info(key_name)
 
 if __name__ == "__main__":
-    main()
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config", type=str, default="config/config.yaml", help="YAML with keys: [lab1, ...]")
+    args = parser.parse_args()
+
+    main(args.config)

--- a/openreal2sim/preprocess/preprocess_manager.py
+++ b/openreal2sim/preprocess/preprocess_manager.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+import argparse
+import sys
+from pathlib import Path
+
+
+class PreprocessManager:
+    def __init__(self, config_file: str = "config/config.yaml"):
+        self.config_file = config_file
+        self.base_dir = Path.cwd()
+
+        # Verify config file exists
+        config_path = self.base_dir / config_file
+        if not config_path.is_file():
+            raise FileNotFoundError(f"Config file not found: {config_path}")
+
+    def image_extraction(self):
+        from openreal2sim.preprocess.image_extraction import main as image_extraction_main
+        image_extraction_main(self.config_file)
+
+    def depth_prediction(self):
+        from openreal2sim.preprocess.depth_prediction import main as depth_prediction_main
+        depth_prediction_main(self.config_file)
+
+    def depth_calibration(self):
+        from openreal2sim.preprocess.depth_calibration import main as depth_calibration_main
+        depth_calibration_main(self.config_file)
+
+    def run(self):
+        print(f"Starting Preprocess manager with config file {self.config_file}")
+        try:
+            self.image_extraction()
+            self.depth_prediction()
+            self.depth_calibration()
+            return True
+
+        except Exception as e:
+            import traceback
+            traceback.print_exc()
+            return False
+
+
+def main(config_file: str = "config/config.yaml"):
+    manager = PreprocessManager(config_file=config_file)
+    success = manager.run()
+    sys.exit(0 if success else 1)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--config",
+        type=str,
+        default="config/config.yaml",
+        help="Path to YAML config file with keys: [lab1, ...]"
+    )
+    args = parser.parse_args()
+
+    main(args.config)

--- a/scripts/running/preprocess.sh
+++ b/scripts/running/preprocess.sh
@@ -1,4 +1,0 @@
-#preprocess
-python openreal2sim/preprocess/image_extraction.py
-python openreal2sim/preprocess/depth_prediction.py
-python openreal2sim/preprocess/depth_calibration.py


### PR DESCRIPTION
Currently all the preprocess steps can be executed by running bash scripts/running/preprocess.sh

This PR creates a python script to substitute the above command, the new script allows to run a custom config file instead of always running config/config.yaml

I used this to run the preprocess pipeline for different batches at the same time, without worrying about modifying the same config file