### PR TITLE
Fix Propagation when running as part of recon_agent

### DIFF
--- a/openreal2sim/reconstruction/recon_agent.py
+++ b/openreal2sim/reconstruction/recon_agent.py
@@ -96,7 +96,7 @@ class ReconAgent:
 
     def mask_propagation(self):
         from tools.segmentation_mask_propagation import mask_propagation
-        mask_propagation(self.keys)
+        self.key_scene_dicts = mask_propagation(self.keys, self.key_scene_dicts)
         print("[Info] Mask propagation completed.")
 
     def background_pixel_inpainting(self):

--- a/openreal2sim/reconstruction/tools/segmentation_mask_propagation.py
+++ b/openreal2sim/reconstruction/tools/segmentation_mask_propagation.py
@@ -137,12 +137,14 @@ def propagate_maks(segmented_video: object, output_directory: Path):
 #========================================================================================
 # Main
 #========================================================================================
-def mask_propagation(keys):
+def mask_propagation(keys, key_scene_dicts):
     for key in keys:
         print("propagating for", key)
         with open(OUT_ROOT/key/"scene/scene.pkl", "rb") as f:
-            segmented_video = pickle.load(f)
-            propagate_maks(segmented_video, OUT_ROOT/key)
+            scene = pickle.load(f)
+        propagate_maks(scene, OUT_ROOT/key)
+        key_scene_dicts[key] = scene
+    return key_scene_dicts
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Propagation was failing when running as part of the recon_agent becaue the dictionary of scenes was not being updated