### PR TITLE
Remove user specification from Docker service

### DIFF
--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -33,7 +33,6 @@ services:
       context: ..
       dockerfile: docker/isaaclab/Dockerfile
     image: isaaclab:dev
-    user: "${HOST_UID}:${HOST_GID}"
     deploy:
       resources:
         reservations:


### PR DESCRIPTION
Removed user specification from the Docker service.

it was sometimes logging into the container as:

bash: /home/isaac/.bashrc: Permission denied
I have no name!@SYSTEM-NAME:/app